### PR TITLE
Hoist per-event Consumer allocation in EventProcessor.updat

### DIFF
--- a/mobiuskt-core/src/commonMain/kotlin/EventProcessor.kt
+++ b/mobiuskt-core/src/commonMain/kotlin/EventProcessor.kt
@@ -18,16 +18,12 @@ internal class EventProcessor<M, E, F> internal constructor(
     private val modelConsumer: Consumer<M>
 ) {
     private val lock = SynchronizedObject()
+    private val consumer = Consumer<M> { value -> dispatchModel(value) }
 
     fun update(event: E): Unit = synchronized(lock) {
         val next = store.update(event)
 
-        next.ifHasModel(
-            object : Consumer<M> {
-                override fun accept(value: M) {
-                    dispatchModel(value)
-                }
-            })
+        next.ifHasModel(consumer)
         dispatchEffects(next.effects())
     }
 


### PR DESCRIPTION
Summary
 - EventProcessor.update() allocated a fresh anonymous Consumer<M> on every call just to forward the model to dispatchModel. Since that consumer is stateless (it only closes over this), it's now built once as an instance field and reused for the lifetime of the EventProcessor.

Test plan 
- No new tests added — existing EventProcessorTest (shouldEmitStateIfStateChanged, shouldNotEmitStateIfStateNotChanged, shouldOnlyEmitStateStateChanged, shouldEmitEffectsWhenStateChanges) already exercises repeated update() calls on the same instance with mixed changed/unchanged models, which is the only scenario that could expose a regression from consumer reuse.
-  ./gradlew :mobiuskt-core:jvmTest pass
